### PR TITLE
chore: add start job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
           curl -fsSL https://deno.land/x/install/install.sh | sh -s ${{ env.DENO_VERSION }}
           echo "$HOME/.deno/bin" >> $GITHUB_PATH
 
-      - name: Run linter
-        run: ./start -v
+      - name: Print version
+        run: ./start.sh -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,18 @@ jobs:
 
       - name: Run linter
         run: deno lint
+
+  start:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Install Deno
+        run: |-
+          curl -fsSL https://deno.land/x/install/install.sh | sh -s ${{ env.DENO_VERSION }}
+          echo "$HOME/.deno/bin" >> $GITHUB_PATH
+
+      - name: Run linter
+        run: ./start -v


### PR DESCRIPTION
Ensuring the program can at least compile and print out the version is a better than no tests at all right?